### PR TITLE
Fix for an edge case

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -28,7 +28,7 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess, JsonSeria
         unset($this->items[$key]);
     }
 
-    public function offsetGet($key)
+    public function offsetGet($key): mixed
     {
         return $this->items[$key];
     }
@@ -62,7 +62,7 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess, JsonSeria
         return $this->items;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -23,7 +23,7 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess, JsonSeria
         );
     }
 
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
         unset($this->items[$key]);
     }
@@ -33,7 +33,7 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess, JsonSeria
         return $this->items[$key];
     }
 
-    public function offsetExists($key)
+    public function offsetExists($key): bool
     {
         return isset($this->items[$key]);
     }
@@ -43,7 +43,7 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess, JsonSeria
         return new ArrayIterator($this->items);
     }
 
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         if (is_null($key)) {
             $this->items[] = $value;

--- a/src/Line.php
+++ b/src/Line.php
@@ -10,7 +10,7 @@ class Line implements JsonSerializable
 
     public string $body;
 
-    public function __construct(string $timestamp, string $body)
+    public function __construct(string $timestamp, string $body = '')
     {
         $this->timestamp = new TimestampSpan($timestamp);
         $this->body = $body;

--- a/src/Transcription.php
+++ b/src/Transcription.php
@@ -38,7 +38,7 @@ class Transcription
         // 2. Then, we'll remove all empty lines or numeric headlines.
         $lines = array_filter(
             array_map("trim", $lines),
-            fn($line) => $line && !is_numeric($line)
+            fn($line) => $line && !preg_match('/^[0-9]+$/', $line)
         );
 
         // 3. Finally, we'll allow for multi-line strings.


### PR DESCRIPTION
When a single word sentence is a number - or in this case a year, it would muck up the rest of the output.

```vtt
…

61
00:08:16.600 --> 00:08:18.600
The year is 1975.

62
00:08:19.699 --> 00:08:21.100
1975.

…
```